### PR TITLE
Fix translation

### DIFF
--- a/csv/list_1.csv
+++ b/csv/list_1.csv
@@ -8,7 +8,7 @@
 進める,進(すす)める,"v. [*transitive verb 他動詞]
 1. move forward, proceed with (something)
 2. work on ",このチケットは、Kenさんと一緒に進めています。,このチケットは、Kenさんと一緒(いっしょ)に進(すす)めています。,I'm working on this ticket with Ken.
-[システムが]動く,[システムが]動(うご)く,"v. work, operate ",システムがちゃんと動いてないことがわかった。,システムがちゃんと動(うご)いてないことがわかった。,I realized that the system was not working properly. 
+[システムが]動く,[システムが]動(うご)く,"v. work, operate ",システムがちゃんと動いてないことがわかった。,システムがちゃんと動(うご)いてないことがわかった。,I realized that the system has not been working properly. 
 ちゃんと,ちゃんと ※casual,adv. properly,ー,ー,ー
 間に合う,間(ま)に合(あ)う,"be in time, make a deadline",来週のリリースには間に合いそうです。,来週(らいしゅう)のリリースには間(ま)に合(あ)いそうです。,It seems that we'll make the release next week.
 状態,状態(じょうたい),n. status,QAしてもらえる状態のものがありますか。,QAしてもらえる状態(じょうたい)のものがありますか。,Is there anything ready for QA?


### PR DESCRIPTION
> システムがちゃんと動いてないことがわかった。

は「現在も動いていない（ので対応が必要）」と読み取れますが、

> I realized that the system was not working properly. 

と言ってしまうと、
「動いていなかったけど現在は直った（ので対応不要）」と伝わってしまうかなと心配になりました。